### PR TITLE
Fix route path typo in visitorRoute by changing '/hoste/:hostelId' to…

### DIFF
--- a/src/routes/visitorRoute.ts
+++ b/src/routes/visitorRoute.ts
@@ -64,7 +64,7 @@ visitorRouter.put(
   visitorController.checkoutVisitorController
 );
 visitorRouter.get(
-  "/hoste/:hostelId",
+  "/hostel/:hostelId",
   authenticateJWT,
   authorizeRole(["SUPER_ADMIN", "ADMIN"]),
   validateHostelAccess,


### PR DESCRIPTION
… '/hostel/:hostelId' for correct endpoint access.